### PR TITLE
[cisco-nso] Update template to reference correct values key

### DIFF
--- a/charts/cisco-nso/Chart.yaml
+++ b/charts/cisco-nso/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 7.3.4
+version: 7.3.5
 name: cisco-nso
 description: Cisco Network Services Orchestrator (NSO)
 # renovate: image=ghcr.io/cisco-nso-prod

--- a/charts/cisco-nso/templates/statefulset.yaml
+++ b/charts/cisco-nso/templates/statefulset.yaml
@@ -332,7 +332,7 @@ spec:
               subPath: 50-merge-config.py
             {{- range $name, $_ := .Values.customPreNcsStartScripts }}
             - name: custom-pre-ncs-start
-              mountPath: {{ printf "%s/pre-ncs-start.d/%s" .Values.ncs.configPath $name }}
+              mountPath: {{ printf "%s/pre-ncs-start.d/%s" $.Values.ncs.configPath $name }}
               subPath: {{ $name | quote }}
             {{- end }}
             {{- if .Values.logRotate.enabled }}
@@ -342,7 +342,7 @@ spec:
             {{- end }}
             {{- range $name, $_ := .Values.customPostNcsStartScripts }}
             - name: custom-post-ncs-start
-              mountPath: {{ printf "%s/post-ncs-start.d/%s" .Values.ncs.configPath $name }}
+              mountPath: {{ printf "%s/post-ncs-start.d/%s" $.Values.ncs.configPath $name }}
               subPath: {{ $name | quote }}
             {{- end }}
             {{- if .Values.auth.ipc.enabled }}


### PR DESCRIPTION
Hey, noticed a missing root anchor $ thing in the loop causing the rendering to fail when using the Pre / post ncs start scripts.

Example error:
```
Generate tmp/dev/_manifests.yaml...
Error: cisco-nso/templates/statefulset.yaml:335:66
  executing "cisco-nso/templates/statefulset.yaml" at <.Values.ncs.configPath>:
    can't evaluate field Values in type interface {}
```