### PR TITLE
[cisco-nso] Fix typo in IPC secret path

### DIFF
--- a/charts/cisco-nso/Chart.yaml
+++ b/charts/cisco-nso/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-version: 7.4.2
+version: 7.4.3
 name: cisco-nso
 description: Cisco Network Services Orchestrator (NSO)
 # renovate: image=cisco-nso-prod

--- a/charts/cisco-nso/templates/ha-raft/job.yaml
+++ b/charts/cisco-nso/templates/ha-raft/job.yaml
@@ -128,7 +128,7 @@ spec:
         {{- if .Values.auth.ipc.enabled }}
         - name: ipc-token
           secret:
-            secretName: {{ include "common.secrets.name" (dict "existingSecret" .Values.haRaft.existingSecret "defaultNameSuffix" "ipc-token" "context" $) }}
+            secretName: {{ include "common.secrets.name" (dict "existingSecret" .Values.auth.ipc.existingSecret "defaultNameSuffix" "ipc-token" "context" $) }}
             defaultMode: 0244
         {{- end }}
 {{- end }}

--- a/charts/cisco-nso/templates/statefulset.yaml
+++ b/charts/cisco-nso/templates/statefulset.yaml
@@ -529,7 +529,7 @@ spec:
         {{- if .Values.auth.ipc.enabled }}
         - name: ipc-token
           secret:
-            secretName: {{ include "common.secrets.name" (dict "existingSecret" .Values.haRaft.existingSecret "defaultNameSuffix" "ipc-token" "context" $) }}
+            secretName: {{ include "common.secrets.name" (dict "existingSecret" .Values.auth.ipc.existingSecret "defaultNameSuffix" "ipc-token" "context" $) }}
             defaultMode: 0244
         {{- end }}
         {{- if .Values.tls.enabled }}


### PR DESCRIPTION
Hey, quick typo in the IPC secret section. 

Haven't confirmed the behaviour but this looks right :)